### PR TITLE
Logging reporting

### DIFF
--- a/import_workflow.py
+++ b/import_workflow.py
@@ -54,12 +54,12 @@ def main(target, datauser, omerouser):
     if json_path:
         print(f'json path will be {json_path}')
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        out_path = pathlib.Path(json_path).parent / timestamp / ".out"
-        err_path = pathlib.Path(json_path).parent / timestamp / ".err"
-        with open(out_path, 'w') as fp:
+        out_path = pathlib.Path(json_path).parent / (timestamp + ".out")
+        err_path = pathlib.Path(json_path).parent / (timestamp + ".err")
+        with open(out_path, 'w+') as fp:
             fp.write(stdoutval)
         fp.close()
-        with open(err_path, 'w') as fp:
+        with open(err_path, 'w+') as fp:
             fp.write(stderrval)
         fp.close()
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -18,7 +18,7 @@ def demote(user_uid, user_gid, homedir):
 
 
 def retrieve_json(stdoutval):
-    if (stdoutval == "\n"):
+    if (stdoutval == ""):
         print("empty stdout")
     last_line = stdoutval.split('\n')[-2]
     json_path = last_line.split(':')[-1].strip()

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -19,6 +19,7 @@ def demote(user_uid, user_gid, homedir):
 
 def retrieve_json(stdoutval):
     last_line = stdoutval.split('\n')[-2]
+    print(last_line)
     json_path = last_line.split(':')[-1].strip()
     return json_path
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -5,7 +5,6 @@ import pwd
 import sys
 import grp
 import pathlib
-import logging
 from datetime import datetime
 
 
@@ -26,10 +25,6 @@ def retrieve_json(stdoutval):
 
 
 def main(target, datauser, omerouser):
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    logfile = pathlib.Path(target) / pathlib.Path(f'{timestamp}.log')
-    print("log file path:", logfile)
-    logging.basicConfig(filename=logfile, level=logging.DEBUG)
 
     # Data user info
     data_user_uid = pwd.getpwnam(datauser).pw_uid

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -19,7 +19,7 @@ def demote(user_uid, user_gid, homedir):
 
 def retrieve_json(stdoutval):
     last_line = stdoutval.split('\n')[-2]
-    if (last_line == ""):
+    if (last_line == "\n"):
         print("empty last line")
     json_path = last_line.split(':')[-1].strip()
     return json_path
@@ -53,7 +53,8 @@ def main(target, datauser, omerouser):
                                stderr=subprocess.PIPE)
     stdoutval, stderrval = process.communicate()
     stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
-    print(stdoutval, stderrval)
+    print("stdout:",stdoutval)
+    print("stderr:",stderrval)
     json_path = retrieve_json(stdoutval)
     print(f'json path will be {json_path}')
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -18,8 +18,9 @@ def demote(user_uid, user_gid, homedir):
 
 
 def retrieve_json(stdoutval):
-    print(stdoutval)
     last_line = stdoutval.split('\n')[-2]
+    if (last_line == ""):
+        print("empty last line")
     json_path = last_line.split(':')[-1].strip()
     return json_path
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -4,6 +4,8 @@ import argparse
 import pwd
 import sys
 import grp
+import pathlib
+import datetime
 
 
 def demote(user_uid, user_gid, homedir):
@@ -44,6 +46,15 @@ def main(target, datauser, omerouser):
     print(stdoutval, stderrval)
     json_path = retrieve_json(stdoutval)
     print(f'json path will be {json_path}')
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    out_path = pathlib.Path(json_path).parent / timestamp / ".out"
+    err_path = pathlib.Path(json_path).parent / timestamp / ".err"
+    with open(out_path, 'w') as fp:
+        fp.write(stdoutval)
+    fp.close()
+    with open(err_path, 'w') as fp:
+        fp.write(stderrval)
+    fp.close()
 
     # Run import_annotate_batch.py
     impbatch = [sys.executable, 'import_annotate_batch.py', json_path]
@@ -56,7 +67,12 @@ def main(target, datauser, omerouser):
     stdoutval, stderrval = process.communicate()
     stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
     print(stdoutval, stderrval)
-
+    with open(out_path, 'a') as fp:
+        fp.write(stdoutval)
+    fp.close()
+    with open(err_path, 'a') as fp:
+        fp.write(stderrval)
+    fp.close()
 
 if __name__ == '__main__':
     description = "One-command in-place importing sript"

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -33,8 +33,10 @@ def main(target, datauser, omerouser):
     omero_user_gid = data_user_gid
     omero_user_home = f"/home/{omerouser}"
 
+    curr_folder = os.path.abspath(os.path.dirname(__file__))
+
     # Run prepare_batch.py
-    prepbatch = [sys.executable, 'prepare_batch.py', target]
+    prepbatch = [sys.executable, curr_folder + '/prepare_batch.py', target]
     process = subprocess.Popen(prepbatch,
                                preexec_fn=demote(data_user_uid,
                                                  data_user_gid,
@@ -57,7 +59,7 @@ def main(target, datauser, omerouser):
     fp.close()
 
     # Run import_annotate_batch.py
-    impbatch = [sys.executable, 'import_annotate_batch.py', json_path]
+    impbatch = [sys.executable, curr_folder + '/import_annotate_batch.py', json_path]
     process = subprocess.Popen(impbatch,
                                preexec_fn=demote(omero_user_uid,
                                                  omero_user_gid,

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -18,8 +18,8 @@ def demote(user_uid, user_gid, homedir):
 
 
 def retrieve_json(stdoutval):
+    print(stdoutval)
     last_line = stdoutval.split('\n')[-2]
-    print(last_line)
     json_path = last_line.split(':')[-1].strip()
     return json_path
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -5,7 +5,8 @@ import pwd
 import sys
 import grp
 import pathlib
-import datetime
+import logging
+from datetime import datetime
 
 
 def demote(user_uid, user_gid, homedir):
@@ -23,6 +24,11 @@ def retrieve_json(stdoutval):
 
 
 def main(target, datauser, omerouser):
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    logfile = pathlib.Path(target) / pathlib.Path(f'{timestamp}.log')
+    print("log file path:", logfile)
+    logging.basicConfig(filename=logfile, level=logging.DEBUG)
+
     # Data user info
     data_user_uid = pwd.getpwnam(datauser).pw_uid
     data_user_gid = grp.getgrnam('omeroadmin').gr_gid

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -18,9 +18,9 @@ def demote(user_uid, user_gid, homedir):
 
 
 def retrieve_json(stdoutval):
+    if (stdoutval == "\n"):
+        print("empty stdout")
     last_line = stdoutval.split('\n')[-2]
-    if (last_line == "\n"):
-        print("empty last line")
     json_path = last_line.split(':')[-1].strip()
     return json_path
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -18,8 +18,8 @@ def demote(user_uid, user_gid, homedir):
 
 
 def retrieve_json(stdoutval):
-    if (stdoutval == ""):
-        print("empty stdout")
+    if (not stdoutval):
+        return None
     last_line = stdoutval.split('\n')[-2]
     json_path = last_line.split(':')[-1].strip()
     return json_path
@@ -56,34 +56,35 @@ def main(target, datauser, omerouser):
     print("stdout:",stdoutval)
     print("stderr:",stderrval)
     json_path = retrieve_json(stdoutval)
-    print(f'json path will be {json_path}')
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    out_path = pathlib.Path(json_path).parent / timestamp / ".out"
-    err_path = pathlib.Path(json_path).parent / timestamp / ".err"
-    with open(out_path, 'w') as fp:
-        fp.write(stdoutval)
-    fp.close()
-    with open(err_path, 'w') as fp:
-        fp.write(stderrval)
-    fp.close()
+    if json_path:
+        print(f'json path will be {json_path}')
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        out_path = pathlib.Path(json_path).parent / timestamp / ".out"
+        err_path = pathlib.Path(json_path).parent / timestamp / ".err"
+        with open(out_path, 'w') as fp:
+            fp.write(stdoutval)
+        fp.close()
+        with open(err_path, 'w') as fp:
+            fp.write(stderrval)
+        fp.close()
 
-    # Run import_annotate_batch.py
-    impbatch = [sys.executable, curr_folder + '/import_annotate_batch.py', json_path]
-    process = subprocess.Popen(impbatch,
-                               preexec_fn=demote(omero_user_uid,
-                                                 omero_user_gid,
-                                                 omero_user_home),
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-    stdoutval, stderrval = process.communicate()
-    stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
-    print(stdoutval, stderrval)
-    with open(out_path, 'a') as fp:
-        fp.write(stdoutval)
-    fp.close()
-    with open(err_path, 'a') as fp:
-        fp.write(stderrval)
-    fp.close()
+        # Run import_annotate_batch.py
+        impbatch = [sys.executable, curr_folder + '/import_annotate_batch.py', json_path]
+        process = subprocess.Popen(impbatch,
+                                preexec_fn=demote(omero_user_uid,
+                                                    omero_user_gid,
+                                                    omero_user_home),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        stdoutval, stderrval = process.communicate()
+        stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
+        print(stdoutval, stderrval)
+        with open(out_path, 'a') as fp:
+            fp.write(stdoutval)
+        fp.close()
+        with open(err_path, 'a') as fp:
+            fp.write(stderrval)
+        fp.close()
 
 if __name__ == '__main__':
     description = "One-command in-place importing sript"

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -97,10 +97,11 @@ class DataMover:
         # Move files indicated in import.json
         for target in self.import_targets:
             src_fp = self.import_path / target['filename']
+            file = str(target['filename'])
             result = file_mover(src_fp, self.server_path)
             if result is not None:
                 print(f'File moved to {result}')
-                self.logger.debug(f'Success moving file to {result}. It will be imported.')
+                self.logger.debug(f'Success moving file {file} to the server. It will be imported.')
                 os.chmod(result, FILE_PERM)
 
         # Move import.json

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -33,6 +33,7 @@ def file_mover(file_path, destination_dir, tries=3):
     """Safely move a file to a destination directory. Will retry if initial
     attempts result in mismatching md5 digests.
     """
+    logger = logging.getLogger('intake')
     file_path = Path(file_path)
     destination_dir = Path(destination_dir)
     if file_path.exists() and destination_dir.exists():
@@ -45,9 +46,9 @@ def file_mover(file_path, destination_dir, tries=3):
             else:
                 fp = str(file_path)
                 err = f"checksum failed after copy attempt {i + 1} for {fp}"
-                logging.error(err)
+                logger.error(err)
                 os.remove(dest_file)
-    logging.error(f"Unable to copy {str(file_path)}")
+    logger.error(f"Unable to copy {str(file_path)}")
     return None
 
 
@@ -76,6 +77,7 @@ class DataMover:
     """
 
     def __init__(self, import_json_path):
+        self.logger = logging.getLogger('intake')
         self.import_json_path = Path(import_json_path)
 
         if not self.import_json_path.exists():
@@ -98,6 +100,7 @@ class DataMover:
             result = file_mover(src_fp, self.server_path)
             if result is not None:
                 print(f'File moved to {result}')
+                self.logger.debug('Success moving file to {result}. It will be imported.')
                 os.chmod(result, FILE_PERM)
 
         # Move import.json

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -100,7 +100,7 @@ class DataMover:
             result = file_mover(src_fp, self.server_path)
             if result is not None:
                 print(f'File moved to {result}')
-                self.logger.debug('Success moving file to {result}. It will be imported.')
+                self.logger.debug(f'Success moving file to {result}. It will be imported.')
                 os.chmod(result, FILE_PERM)
 
         # Move import.json

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -179,9 +179,8 @@ class ImportBatch:
         self.server_path = None  # where images will live on server
         self.conn = conn  # OMERO connection
         self.import_target_list = []  # List of ImportTarget objects\
-        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        self.logfile = self.import_path / pathlib.Path(f'{timestamp}.log')
-        logging.basicConfig(filename=self.logfile, level=logging.DEBUG)
+        
+        
 
     def load_md(self, sheet_name="Submission Form"):
         """Populate self.md
@@ -221,8 +220,7 @@ class ImportBatch:
                 userlist.extend(group_summary[1])
                 userlist = [u.getName() for u in userlist]
                 if user not in userlist:
-                    logging.error(f'User {user} is not in group {group} and/or user {user} does not exist. Please double-check \
-                                    the spelling and note that usernames and group names are case sensitive!')
+                    logging.error(f'User {user} is not in group {group} and/or user {user} does not exist. Please double-check the spelling and note that usernames and group names are case sensitive!')
                     raise ValueError('User non-existent or not in group.')
                 else:
                     self.user = user
@@ -311,8 +309,7 @@ class ImportBatch:
             if imp_target.exists:
                 imp_target.validate_target()
             else:
-                err = f'Target does not exist: {imp_target.path_to_target}. This file is in your spreadsheet \
-                        but not in your folder, and will not be imported.'
+                err = f'Target does not exist: {imp_target.path_to_target}. This file is in your spreadsheet but not in your folder, and will not be imported.'
                 logging.error(err)
             if imp_target.valid_target is True:
                 self.import_target_list.append(imp_target)
@@ -327,8 +324,7 @@ class ImportBatch:
         mandatory = [self.user, self.group, self.user_email,
                      self.md, self.server_path]
         if None in mandatory:
-            logging.error("Cannot write import.json, missing or wrong information in one of the following items:\
-                            username, group, metadata spreadsheet")
+            logging.error("Cannot write import.json, missing or wrong information in one of the following items: username, group, metadata spreadsheet")
             return False
         elif self.valid_md is False:
             logging.error("Cannot write import.json, metadata spreadsheet contains invalid values.")

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -185,7 +185,6 @@ class ImportBatch:
     def set_logging(self):
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
         logfile = pathlib.Path(self.import_path) / pathlib.Path(f'{timestamp}.log')
-        print("log file path:", logfile)
         self.logger.setLevel(logging.DEBUG)
         fh = logging.FileHandler(logfile)
         fh.setLevel(logging.DEBUG)

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -60,10 +60,10 @@ def find_md_file(import_directory):
         if f.suffix.endswith('xlsx'):
             md_files.append(f)
     if len(md_files) == 0:
-        logging.error('No valid metadata file found')
+        logging.error('No valid metadata file found - have you added an Excel spreadsheet to your files?')
         md_filepath = None
     elif len(md_files) > 1:
-        logging.error('>1 metadata files found, can not process')
+        logging.error('>1 metadata files found, can not process. Is your spreadsheet open? Please close it!')
         md_filepath = None
     else:
         md_filepath = md_files[0]
@@ -96,16 +96,22 @@ def load_md_from_file(md_filepath, sheet_name=0):
         return None
     md_filepath = pathlib.Path(md_filepath)
     if not md_filepath.exists():
+        logging.error(f'Cannot find file {md_filepath} - have you moved it?')
         raise FileNotFoundError(f'No such file: {md_filepath}')
     if md_filepath.suffix != '.xlsx':
+        logging.error('Only spreadsheets with xlsx extensions are accepted. Please use our template for submission!')
         raise ValueError('File suffix must be xlsx')
 
-    md_header = pd.read_excel(md_filepath,
+    try:
+        md_header = pd.read_excel(md_filepath,
                               sheet_name=sheet_name,
                               nrows=4,
                               index_col=0,
                               header=None,
                               engine="openpyxl")
+    except KeyError:
+        logging.error("Your spreadsheet does not have a Submission Form sheet - please use our template for submission!")
+        raise KeyError(f"Worksheet {sheet_name} does not exist.")
     md = pd.read_excel(md_filepath,
                        sheet_name=sheet_name,
                        skiprows=range(4),
@@ -172,7 +178,10 @@ class ImportBatch:
         self.valid_md = False
         self.server_path = None  # where images will live on server
         self.conn = conn  # OMERO connection
-        self.import_target_list = []  # List of ImportTarget objects
+        self.import_target_list = []  # List of ImportTarget objects\
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        self.logfile = self.import_path / pathlib.Path(f'{timestamp}.log')
+        logging.basicConfig(filename=self.logfile, level=logging.DEBUG)
 
     def load_md(self, sheet_name="Submission Form"):
         """Populate self.md
@@ -212,16 +221,18 @@ class ImportBatch:
                 userlist.extend(group_summary[1])
                 userlist = [u.getName() for u in userlist]
                 if user not in userlist:
-                    logging.error(f'User {user} is not in group {group}.')
-                    return False
+                    logging.error(f'User {user} is not in group {group} and/or user {user} does not exist. Please double-check \
+                                    the spelling and note that usernames and group names are case sensitive!')
+                    raise ValueError('User non-existent or not in group.')
                 else:
                     self.user = user
                     userid = get_user_id(self.conn, self.user)
                     user_obj = self.conn.getObject('Experimenter', userid)
                     self.user_email = user_obj._obj.email._val
                     return True
-        logging.error(f'Group {group} was not found.')
-        return False
+        logging.error(f'Group {group} was not found. Please double-check the spelling and note that usernames and group names are case sensitive!')
+        raise ValueError('group not found.')
+
 
     def set_server_path(self):
         """Set ``self.server_path`` based on group, user, and import date.
@@ -254,39 +265,39 @@ class ImportBatch:
         self.valid_md = True
         for filemd in self.md['file_metadata']:
             if 'filename' not in filemd.keys():
-                logging.error('File metadata missing filename')
+                logging.error('Column \'filename\' is missing in your spreadsheet!')
                 self.valid_md = False
                 return False
             elif (str(filemd['filename']) == '' or
                   str(filemd['filename']) == 'nan'):
-                logging.error('filename cannot be empty/blank')
+                logging.error('You have an empty filename in your spreadsheet. Please double-check!')
                 self.valid_md = False
                 return False
 
             if 'dataset' not in filemd.keys():
-                logging.error('File metadata missing dataset')
+                logging.error('Column \'dataset\' is missing in your spreadsheet!')
                 self.valid_md = False
                 return False
             elif (str(filemd['dataset']) == '' or
                   str(filemd['dataset']) == 'nan'):
-                logging.error('dataset name cannot be empty/blank')
+                logging.error('You have an empty dataset name in your spreadsheet. Please double-check!')
                 self.valid_md = False
                 return False
 
             if 'project' not in filemd.keys():
-                logging.error('File metadata missing project')
+                logging.error('Column \'project\' is missing in your spreadsheet!')
                 self.valid_md = False
                 return False
             elif (str(filemd['project']) == '' or
                   str(filemd['project']) == 'nan'):
-                logging.error('project name cannot be empty/blank')
+                logging.error('You have an empty project name in your spreadsheet. Please double-check!')
                 self.valid_md = False
                 return False
 
         # Check for duplicate filenames in metadata
         file_list_md = [f['filename'] for f in self.md['file_metadata']]
         if len(set(file_list_md)) < len(file_list_md):
-            logging.error('Duplicate filenames in metadata')
+            logging.error('Spreadsheet contains duplicate filenames. Please double-check!')
             self.valid_md = False
             return False
 
@@ -300,13 +311,14 @@ class ImportBatch:
             if imp_target.exists:
                 imp_target.validate_target()
             else:
-                err = f'Target does not exist: {imp_target.path_to_target}'
+                err = f'Target does not exist: {imp_target.path_to_target}. This file is in your spreadsheet \
+                        but not in your folder, and will not be imported.'
                 logging.error(err)
             if imp_target.valid_target is True:
                 self.import_target_list.append(imp_target)
             elif imp_target.valid_target is False:
                 err = ('Target can not be imported'
-                       f' by OMERO: {imp_target.path_to_target}')
+                       f' by OMERO: {imp_target.path_to_target}. File might be corrupted or invalid. Skipping.')
                 logging.error(err)
 
     def write_json(self):
@@ -315,13 +327,14 @@ class ImportBatch:
         mandatory = [self.user, self.group, self.user_email,
                      self.md, self.server_path]
         if None in mandatory:
-            logging.error("Cannot write import.json, missing information")
+            logging.error("Cannot write import.json, missing or wrong information in one of the following items:\
+                            username, group, metadata spreadsheet")
             return False
         elif self.valid_md is False:
-            logging.error("Cannot write import.json, missing information")
+            logging.error("Cannot write import.json, metadata spreadsheet contains invalid values.")
             return False
         elif len(self.import_target_list) == 0:
-            logging.error("Cannot write import.json, no valid import targets")
+            logging.error("Cannot write import.json, no valid import targets. Skipping empty import.")
             return False
         else:
             import_json = {}

--- a/jax_omeroutils/tests/test_intake.py
+++ b/jax_omeroutils/tests/test_intake.py
@@ -81,8 +81,10 @@ def test_ImportBatch_validate_ug(conn, users_groups):
     assert batch.user == 'test_user1'
     assert batch.group == 'test_group_1'
     assert batch.user_email == 'useremail@jax.org'
-    assert not batch.validate_user_group(user='test_user1', group='bad_group')
-    assert not batch.validate_user_group(user='bad_user', group='test_group_1')
+    with pytest.raises(ValueError):
+        batch.validate_user_group(user='test_user1', group='bad_group')
+    with pytest.raises(ValueError):
+        batch.validate_user_group(user='bad_user', group='test_group_1')
 
 
 def test_set_server_path():

--- a/prepare_batch.py
+++ b/prepare_batch.py
@@ -22,6 +22,7 @@ def main(import_batch_directory):
                         port=OMERO_PORT)
     conn.connect()
     batch = ImportBatch(conn, import_batch_directory)
+    batch.set_logging()
     batch.load_md()
     batch.validate_import_md()
     batch.validate_user_group()

--- a/prepare_batch.py
+++ b/prepare_batch.py
@@ -31,9 +31,10 @@ def main(import_batch_directory):
     conn.close()
 
     # Move files into place
-    mover = DataMover(import_batch_directory / 'import.json')
-    message = mover.move_data()
-    print(message)
+    if Path(import_batch_directory / 'import.json').exists():
+        mover = DataMover(import_batch_directory / 'import.json')
+        message = mover.move_data()
+        print(message)
     return
 
 


### PR DESCRIPTION
This pull request includes: 

- A fix for issue #10  - we now throw a `ValueError` if user and/or group cannot be validated
- Significant improvement on logging: user-side error (on spreadsheet mistakes, etc) are now logged on a time-stamped `.log` file placed in the dropbox folder. If a json file is generated and an import starts, the server-side folder that is created with the data and json file will also include a `.out` file (with all `stdout` output) and a `.err` file (with all `stderr` output), both time-stamped. This might be enough to solve #8 
- Empty imports do not throw an error any longer. An empty import event is logged in the log file but code goes through, skipping the import steps.