### PR TITLE
Use cli transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 jax_omeroutils.egg-info
 config.py
 
+# build stuff
+build/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A package for working with OMERO by ResearchIT at The Jackson Laboratory.
 
 This repository also contains scripts that use jax-omeroutils for managing commons tasks.
 
+# requirements
+
+In addition to the requirements in `requirements.txt`, due to the fact that we use `omero transfer prepare`,
+you need to have `bftools`. The easiest way to install that is `conda install -c bioconda bftools`.
+
 
 ## A note on plates
 

--- a/auto_import.sh
+++ b/auto_import.sh
@@ -31,6 +31,7 @@ while [ "$#" -gt 0 ]; do
 
 done
 folder="$1"; shift 1;
+echo $folder
 # need to change into a folder where sudo has permission - using folder where script is
 cd "$(dirname "$0")"
 

--- a/auto_import.sh
+++ b/auto_import.sh
@@ -41,7 +41,6 @@ cd "$(dirname "$0")"
 arguments="$*"
 # check for folders last modified more than 60 mins ago
 sudo -u $user find "$folder" -mindepth 1 -maxdepth 1 -type d -mmin +60 | while read dir; do 
-    echo $dir
     skip=false
     if [ "$exclude" ]; then
         for exc in $(cat $exclude); do

--- a/auto_import.sh
+++ b/auto_import.sh
@@ -41,7 +41,7 @@ cd "$(dirname "$0")"
 arguments="$*"
 # check for folders last modified more than 60 mins ago
 sudo -u $user find "$folder" -mindepth 1 -maxdepth 1 -type d -mmin +60 | while read dir; do 
-
+    echo $dir
     skip=false
     if [ "$exclude" ]; then
         for exc in $(cat $exclude); do

--- a/auto_import.sh
+++ b/auto_import.sh
@@ -67,10 +67,6 @@ sudo -u $user find "$folder" -mindepth 1 -maxdepth 1 -type d -mmin +60 | while r
 
         #check whether folder is "empty" now
         empty=false
-        echo "Deleting temp files"
-        rm -f "$dir"/filelist.txt
-        rm -f "$dir"/moved_files.txt
-        rm -f "$dir"/transfer.xml
         allfiles=$(sudo -u $user find "$dir" -mindepth 1 -maxdepth 1 -type f | wc -l)
         nonimages=$(sudo -u $user find "$dir" -mindepth 1 -maxdepth 1 -regex ".*\.\(xlsx\|csv\|log\|json\|db\|ini\|txt\|xml\)" -type f | wc -l)
         echo "Folder has $allfiles files left, of which $nonimages are typical non-images."

--- a/auto_import.sh
+++ b/auto_import.sh
@@ -31,7 +31,6 @@ while [ "$#" -gt 0 ]; do
 
 done
 folder="$1"; shift 1;
-echo $folder
 # need to change into a folder where sudo has permission - using folder where script is
 cd "$(dirname "$0")"
 

--- a/auto_import.sh
+++ b/auto_import.sh
@@ -68,8 +68,11 @@ sudo -u $user find "$folder" -mindepth 1 -maxdepth 1 -type d -mmin +60 | while r
 
         #check whether folder is "empty" now
         empty=false
+        rm -f "$dir"/filelist.txt
+        rm -f "$dir"/moved_files.txt
+        rm -f "$dir"/transfer.xml
         allfiles=$(sudo -u $user find "$dir" -mindepth 1 -maxdepth 1 -type f | wc -l)
-        nonimages=$(sudo -u $user find "$dir" -mindepth 1 -maxdepth 1 -regex ".*\.\(xlsx\|csv\|log\|json\|db\|ini\|txt\)" -type f | wc -l)
+        nonimages=$(sudo -u $user find "$dir" -mindepth 1 -maxdepth 1 -regex ".*\.\(xlsx\|csv\|log\|json\|db\|ini\|txt\|xml\)" -type f | wc -l)
         echo "Folder has $allfiles files left, of which $nonimages are typical non-images."
         if [ $allfiles -eq $nonimages ]; then
             empty=true

--- a/auto_import.sh
+++ b/auto_import.sh
@@ -67,6 +67,7 @@ sudo -u $user find "$folder" -mindepth 1 -maxdepth 1 -type d -mmin +60 | while r
 
         #check whether folder is "empty" now
         empty=false
+        echo "Deleting temp files"
         rm -f "$dir"/filelist.txt
         rm -f "$dir"/moved_files.txt
         rm -f "$dir"/transfer.xml

--- a/import_annotate_batch.py
+++ b/import_annotate_batch.py
@@ -7,8 +7,6 @@ import argparse
 import json
 from jax_omeroutils.config import OMERO_USER, OMERO_PASS
 from jax_omeroutils.config import OMERO_HOST, OMERO_PORT
-from jax_omeroutils.importer import Importer
-from omero.gateway import BlitzGateway
 from pathlib import Path
 import subprocess
 import sys
@@ -40,8 +38,7 @@ def main(import_md):
     print("stdout unpack:", stdoutval)
     print("stderr unpack:", stderrval)
 
-
-    # # Create user connection
+    # Create user connection
     # suconn = BlitzGateway(OMERO_USER,
     #                       OMERO_PASS,
     #                       host=OMERO_HOST,
@@ -50,12 +47,11 @@ def main(import_md):
     # suconn.connect()
     # conn = suconn.suConn(import_user, import_group, 2160000000)
     # suconn.close()
-    
+
     # # do I need a session key for conn? can I pass --sudo on transfer itself?
     # # you should be able to pass --sudo on transfer!
 
-
-    # # Import targets from import.json
+    # Import targets from import.json
     # for md in file_metadata:
     #     filename = md['filename']
     #     file_path = data_dir / filename

--- a/import_annotate_batch.py
+++ b/import_annotate_batch.py
@@ -10,6 +10,7 @@ from jax_omeroutils.config import OMERO_HOST, OMERO_PORT
 from jax_omeroutils.importer import Importer
 from omero.gateway import BlitzGateway
 from pathlib import Path
+import subprocess
 
 
 def main(import_md):
@@ -20,44 +21,59 @@ def main(import_md):
 
     import_user = batch_md['user']
     import_group = batch_md['group']
-    file_metadata = batch_md['import_targets']
+    # file_metadata = batch_md['import_targets']
     data_dir = Path(batch_md['server_path'])
 
-    # Create user connection
-    suconn = BlitzGateway(OMERO_USER,
-                          OMERO_PASS,
-                          host=OMERO_HOST,
-                          port=OMERO_PORT,
-                          secure=True)
-    suconn.connect()
-    conn = suconn.suConn(import_user, import_group, 2160000000)
-    suconn.close()
+    unpack = ['omero', '-s', OMERO_HOST, '-p', str(OMERO_PORT),
+               '-u', import_user, '-w', OMERO_PASS, '-g', import_group,
+               '--sudo', OMERO_USER,
+               'transfer', 'unpack', data_dir]
+    process = subprocess.Popen(unpack,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE
+                               )
+    stdoutval, stderrval = process.communicate()
+    stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
+    print("stdout unpack:", stdoutval)
+    print("stderr unpack:", stderrval)
+
+
+    # # Create user connection
+    # suconn = BlitzGateway(OMERO_USER,
+    #                       OMERO_PASS,
+    #                       host=OMERO_HOST,
+    #                       port=OMERO_PORT,
+    #                       secure=True)
+    # suconn.connect()
+    # conn = suconn.suConn(import_user, import_group, 2160000000)
+    # suconn.close()
     
-    # do I need a session key for conn? can I pass --sudo on transfer itself?
+    # # do I need a session key for conn? can I pass --sudo on transfer itself?
+    # # you should be able to pass --sudo on transfer!
 
 
-    # Import targets from import.json
-    for md in file_metadata:
-        filename = md['filename']
-        file_path = data_dir / filename
-        print(f'Preparing to import {str(file_path)}')
-        imp_ctl = Importer(conn, file_path, md)
-        imp_ctl.import_ln_s(OMERO_HOST, OMERO_PORT)
-        print("import done")
-        if imp_ctl.screen:
-            print("it's a screen")
-            imp_ctl.get_plate_ids()
-            print(f"plate ids get! {str(imp_ctl.plate_ids[0])}")
-            imp_ctl.organize_plates()
-            print("plate organized")
-            imp_ctl.annotate_plates()
-            print("plate annotated")
-        else:
-            imp_ctl.get_image_ids()
-            imp_ctl.organize_images()
-            imp_ctl.annotate_images()
+    # # Import targets from import.json
+    # for md in file_metadata:
+    #     filename = md['filename']
+    #     file_path = data_dir / filename
+    #     print(f'Preparing to import {str(file_path)}')
+    #     imp_ctl = Importer(conn, file_path, md)
+    #     imp_ctl.import_ln_s(OMERO_HOST, OMERO_PORT)
+    #     print("import done")
+    #     if imp_ctl.screen:
+    #         print("it's a screen")
+    #         imp_ctl.get_plate_ids()
+    #         print(f"plate ids get! {str(imp_ctl.plate_ids[0])}")
+    #         imp_ctl.organize_plates()
+    #         print("plate organized")
+    #         imp_ctl.annotate_plates()
+    #         print("plate annotated")
+    #     else:
+    #         imp_ctl.get_image_ids()
+    #         imp_ctl.organize_images()
+    #         imp_ctl.annotate_images()
 
-    conn.close()
+    # conn.close()
     return
 
 

--- a/import_annotate_batch.py
+++ b/import_annotate_batch.py
@@ -11,6 +11,7 @@ from jax_omeroutils.importer import Importer
 from omero.gateway import BlitzGateway
 from pathlib import Path
 import subprocess
+import sys
 
 
 def main(import_md):
@@ -24,10 +25,12 @@ def main(import_md):
     # file_metadata = batch_md['import_targets']
     data_dir = Path(batch_md['server_path'])
 
-    unpack = ['omero', '-s', OMERO_HOST, '-p', str(OMERO_PORT),
-               '-u', import_user, '-w', OMERO_PASS, '-g', import_group,
-               '--sudo', OMERO_USER,
-               'transfer', 'unpack', '--ln_s', '--folder', data_dir, '--merge']
+    env_folder = Path(sys.executable).parent
+    omero_path = str(env_folder / "omero")
+    unpack = [omero_path, '-s', OMERO_HOST, '-p', str(OMERO_PORT),
+              '-u', import_user, '-w', OMERO_PASS, '-g', import_group,
+              '--sudo', OMERO_USER,
+              'transfer', 'unpack', '--ln_s', '--folder', data_dir, '--merge']
     process = subprocess.Popen(unpack,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE

--- a/import_annotate_batch.py
+++ b/import_annotate_batch.py
@@ -32,6 +32,9 @@ def main(import_md):
     suconn.connect()
     conn = suconn.suConn(import_user, import_group, 2160000000)
     suconn.close()
+    
+    # do I need a session key for conn? can I pass --sudo on transfer itself?
+
 
     # Import targets from import.json
     for md in file_metadata:

--- a/import_annotate_batch.py
+++ b/import_annotate_batch.py
@@ -27,7 +27,7 @@ def main(import_md):
     unpack = ['omero', '-s', OMERO_HOST, '-p', str(OMERO_PORT),
                '-u', import_user, '-w', OMERO_PASS, '-g', import_group,
                '--sudo', OMERO_USER,
-               'transfer', 'unpack', data_dir]
+               'transfer', 'unpack', '--ln_s', '--folder', data_dir, '--merge']
     process = subprocess.Popen(unpack,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE

--- a/import_annotate_batch.py
+++ b/import_annotate_batch.py
@@ -38,6 +38,7 @@ def main(import_md):
     print("stdout unpack:", stdoutval)
     print("stderr unpack:", stderrval)
 
+    # LEGACY CODE
     # Create user connection
     # suconn = BlitzGateway(OMERO_USER,
     #                       OMERO_PASS,

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -59,7 +59,7 @@ def main(target, datauser, omerouser, logdir):
 
     # Data user info
     data_user_uid = pwd.getpwnam(datauser).pw_uid
-    data_user_gid = grp.getgrnam('omerodamin').gr_gid
+    data_user_gid = grp.getgrnam('omeroadmin').gr_gid
     data_user_home = f"/home/{datauser}"
 
     # Omero user info

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -47,9 +47,13 @@ def edit_xml(target, datauser, datagroup):
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)
     ome = add_projects_datasets(ome, imp_json)
+    print(ome)
     ome = add_screens(ome, imp_json)
+    print(ome)
     ome = add_annotations(ome, imp_json)
+    print(ome)
     ome = move_objects(ome, imp_json)
+    print(ome)
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)
     return str(pathlib.Path(target) / "transfer.xml")

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -7,7 +7,7 @@ import grp
 import pathlib
 import json
 from jax_omeroutils.xml_editor import add_projects_datasets, add_screens
-from jax_omeroutils.xml_editor import add_annotations, move_images
+from jax_omeroutils.xml_editor import add_annotations, move_objects
 from ome_types import from_xml, to_xml
 from datetime import datetime
 from jax_omeroutils.config import OMERO_USER, OMERO_PASS
@@ -49,7 +49,7 @@ def edit_xml(target):
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
     ome = add_annotations(ome, imp_json)
-    ome = move_images(ome, imp_json)
+    ome = move_objects(ome, imp_json)
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)
     return

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -38,7 +38,7 @@ def retrieve_fileset(stdoutval, target, datauser, datagroup):
         f.write("\n".join(files))
         f.close()
     os.chown(filelist_path, datauser, datagroup)
-    os.chmod(filelist_path, 766)
+    os.chmod(filelist_path, 0o766)
     return filelist_path
 
 
@@ -105,9 +105,9 @@ def main(target, datauser, omerouser, logdir):
                                stderr=subprocess.PIPE
                                )
     if pathlib.Path(filelist).exists():
-        os.chmod(filelist, 766)
+        os.chmod(filelist, 0o766)
     if ((pathlib.Path(target) / "transfer.xml").exists()):
-        os.chmod(pathlib.Path(target) / "transfer.xml", 766)
+        os.chmod(pathlib.Path(target) / "transfer.xml", 0o766)
     stdoutval, stderrval = process.communicate()
     stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
     print("stdout prepare:", stdoutval)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -5,6 +5,10 @@ import pwd
 import sys
 import grp
 import pathlib
+import json
+from jax_omeroutils.xml_editor import add_projects_datasets, add_screens
+from jax_omeroutils.xml_editor import add_annotations
+from ome_types import from_xml, to_xml
 from datetime import datetime
 from jax_omeroutils.config import OMERO_USER, OMERO_PASS
 from jax_omeroutils.config import OMERO_HOST, OMERO_PORT
@@ -35,7 +39,18 @@ def retrieve_fileset(stdoutval, target):
         f.close()
     return filelist_path
 
+
 def edit_xml(target):
+    ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
+    with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
+        imp_json = json.load(fp)
+    print(ome)
+    print(imp_json)
+    ome = add_projects_datasets(ome, imp_json)
+    ome = add_screens(ome, imp_json)
+    ome = add_annotations(ome, imp_json)
+    with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
+        print(to_xml(ome), file=fp)
     return
 
 
@@ -43,7 +58,7 @@ def main(target, datauser, omerouser, logdir):
 
     # Data user info
     data_user_uid = pwd.getpwnam(datauser).pw_uid
-    data_user_gid = grp.getgrnam('omeroadmin').gr_gid
+    data_user_gid = grp.getgrnam('erick').gr_gid
     data_user_home = f"/home/{datauser}"
 
     # Omero user info

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -7,7 +7,7 @@ import grp
 import pathlib
 import json
 from jax_omeroutils.xml_editor import add_projects_datasets, add_screens
-from jax_omeroutils.xml_editor import add_annotations
+from jax_omeroutils.xml_editor import add_annotations, move_images
 from ome_types import from_xml, to_xml
 from datetime import datetime
 from jax_omeroutils.config import OMERO_USER, OMERO_PASS
@@ -49,6 +49,7 @@ def edit_xml(target):
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
     ome = add_annotations(ome, imp_json)
+    ome = move_images(ome, imp_json)
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)
     return

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -37,15 +37,11 @@ def retrieve_fileset(stdoutval, target, datauser, datagroup):
     with open(filelist_path, 'w') as f:
         f.write("\n".join(files))
         f.close()
-    os.chown(filelist_path, datauser, datagroup)
-    os.chmod(filelist_path, 0o774)
     return filelist_path
 
 
 def edit_xml(target, datauser, datagroup):
-    os.chmod(pathlib.Path(target) / "transfer.xml", 0o774)
-    os.chown(pathlib.Path(target) / "transfer.xml", datauser, datagroup)
-    ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
+   ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)
     ome = add_projects_datasets(ome, imp_json)
@@ -106,8 +102,6 @@ def main(target, datauser, omerouser, logdir):
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE
                                )
-    if pathlib.Path(filelist).exists():
-        os.chmod(filelist, 0o774)
     stdoutval, stderrval = process.communicate()
     stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
     print("stdout prepare:", stdoutval)
@@ -139,6 +133,13 @@ def main(target, datauser, omerouser, logdir):
     json_path = retrieve_json(stdoutval)
     print("stdout move:", stdoutval)
     print("stderr move:", stderrval)
+    if os.exists(filelist):
+        os.remove(filelist)
+    if os.exists(pathlib.Path(target) / 'moved_files.txt'):
+        os.remove(pathlib.Path(target) / 'moved_files.txt')
+    if os.exists(pathlib.Path(target) / 'transfer.xml'):
+        os.remove(pathlib.Path(target) / 'transfer.xml')
+
     if json_path and pathlib.Path(json_path).exists():
         print(f'json path will be {json_path}')
         out_path = pathlib.Path(json_path).parent / (timestamp + ".out")

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -44,7 +44,7 @@ def retrieve_fileset(stdoutval, target, datauser, datagroup):
 
 def edit_xml(target, datauser, datagroup):
     os.chmod(pathlib.Path(target) / "transfer.xml", 0o774)
-    os.chown(filelist_path, datauser, datagroup)
+    os.chown(pathlib.Path(target) / "transfer.xml", datauser, datagroup)
     ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -48,6 +48,8 @@ def edit_xml(target, datauser, datagroup):
     ome = add_screens(ome, imp_json)
     ome = add_annotations(ome, imp_json)
     ome = move_objects(ome, imp_json)
+    print(ome)
+    print(to_xml(ome))
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)
     return str(pathlib.Path(target) / "transfer.xml")

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -111,6 +111,7 @@ def main(target, datauser, omerouser, logdir):
         f = open(str(pathlib.Path(target) / "import.json"))
         f.close()
     except FileNotFoundError:
+        xml_path=""
         pass
     else:
         xml_path = edit_xml(target)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -133,11 +133,11 @@ def main(target, datauser, omerouser, logdir):
     json_path = retrieve_json(stdoutval)
     print("stdout move:", stdoutval)
     print("stderr move:", stderrval)
-    if os.exists(filelist):
+    if pathlib.Path(filelist).exists():
         os.remove(filelist)
-    if os.exists(pathlib.Path(target) / 'moved_files.txt'):
+    if (pathlib.Path(target) / 'moved_files.txt').exists():
         os.remove(pathlib.Path(target) / 'moved_files.txt')
-    if os.exists(pathlib.Path(target) / 'transfer.xml'):
+    if (pathlib.Path(target) / 'transfer.xml').exists():
         os.remove(pathlib.Path(target) / 'transfer.xml')
 
     if json_path and pathlib.Path(json_path).exists():

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -35,6 +35,9 @@ def retrieve_fileset(stdoutval, target):
         f.close()
     return filelist_path
 
+def edit_xml(target):
+    return
+
 
 def main(target, datauser, omerouser, logdir):
 
@@ -85,6 +88,8 @@ def main(target, datauser, omerouser, logdir):
     stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
     print("stdout prepare:", stdoutval)
     print("stderr prepare:", stderrval)
+
+    edit_xml(target)
 
     # Move data
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -38,11 +38,13 @@ def retrieve_fileset(stdoutval, target, datauser, datagroup):
         f.write("\n".join(files))
         f.close()
     os.chown(filelist_path, datauser, datagroup)
-    os.chmod(filelist_path, 0o766)
+    os.chmod(filelist_path, 0o774)
     return filelist_path
 
 
-def edit_xml(target):
+def edit_xml(target, datauser, datagroup):
+    os.chmod(pathlib.Path(target) / "transfer.xml", 0o774)
+    os.chown(filelist_path, datauser, datagroup)
     ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)
@@ -105,9 +107,7 @@ def main(target, datauser, omerouser, logdir):
                                stderr=subprocess.PIPE
                                )
     if pathlib.Path(filelist).exists():
-        os.chmod(filelist, 0o766)
-    if ((pathlib.Path(target) / "transfer.xml").exists()):
-        os.chmod(pathlib.Path(target) / "transfer.xml", 0o766)
+        os.chmod(filelist, 0o774)
     stdoutval, stderrval = process.communicate()
     stdoutval, stderrval = stdoutval.decode('UTF-8'), stderrval.decode('UTF-8')
     print("stdout prepare:", stdoutval)
@@ -120,7 +120,7 @@ def main(target, datauser, omerouser, logdir):
         xml_path=""
         pass
     else:
-        xml_path = edit_xml(target)
+        xml_path = edit_xml(target, data_user_uid, data_user_gid)
 
     # Move data
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -90,7 +90,6 @@ def main(target, datauser, omerouser, logdir):
     print("stderr prep:", stderrval)
     fileset_list = retrieve_fileset(stdoutval, target,
                                     data_user_uid, data_user_gid)
-    
 
     # Run omero transfer prepare
     env_folder = pathlib.Path(sys.executable).parent
@@ -115,7 +114,7 @@ def main(target, datauser, omerouser, logdir):
         f = open(str(pathlib.Path(target) / "import.json"))
         f.close()
     except FileNotFoundError:
-        xml_path=""
+        xml_path = ""
         pass
     else:
         xml_path = edit_xml(target, data_user_uid, data_user_gid)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -46,11 +46,10 @@ def edit_xml(target):
     ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)
-    print(ome)
-    print(imp_json)
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
     ome = add_annotations(ome, imp_json)
+    print(ome) 
     ome = move_objects(ome, imp_json)
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -88,9 +88,10 @@ def main(target, datauser, omerouser, logdir):
     fileset_list = retrieve_fileset(stdoutval, target)
 
     # Run omero transfer prepare
-
+    env_folder = pathlib.Path(sys.executable).parent
+    omero_path = str(env_folder / "omero")
     filelist = str(pathlib.Path(target) / 'filelist.txt')
-    prepare = ['omero', '-s', OMERO_HOST, '-p', str(OMERO_PORT),
+    prepare = [omero_path, '-s', OMERO_HOST, '-p', str(OMERO_PORT),
                '-u', OMERO_USER, '-w', OMERO_PASS,
                'transfer', 'prepare', '--filelist', filelist,]
     process = subprocess.Popen(prepare,

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -47,7 +47,10 @@ def edit_xml(target, datauser, datagroup):
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
     ome = add_annotations(ome, imp_json)
+    print("after add annotations")
+    print(ome)
     ome = move_objects(ome, imp_json)
+    print("after move objects")
     print(ome)
     print(to_xml(ome))
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -59,7 +59,7 @@ def main(target, datauser, omerouser, logdir):
 
     # Data user info
     data_user_uid = pwd.getpwnam(datauser).pw_uid
-    data_user_gid = grp.getgrnam('erick').gr_gid
+    data_user_gid = grp.getgrnam('omerodamin').gr_gid
     data_user_home = f"/home/{datauser}"
 
     # Omero user info

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -42,12 +42,13 @@ def retrieve_fileset(stdoutval, target, datauser, datagroup):
 
 def edit_xml(target, datauser, datagroup):
     ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
+    print("ome before editing")
+    print(ome)
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
     ome = add_annotations(ome, imp_json)
-    print(ome) 
     ome = move_objects(ome, imp_json)
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -41,7 +41,7 @@ def retrieve_fileset(stdoutval, target, datauser, datagroup):
 
 
 def edit_xml(target, datauser, datagroup):
-   ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
+    ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)
     ome = add_projects_datasets(ome, imp_json)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -46,6 +46,7 @@ def edit_xml(target, datauser, datagroup):
         imp_json = json.load(fp)
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
+    print(ome)
     ome = add_annotations(ome, imp_json)
     print(ome)
     ome = move_objects(ome, imp_json)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -52,7 +52,7 @@ def edit_xml(target):
     ome = move_objects(ome, imp_json)
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)
-    return
+    return str(pathlib.Path(target) / "transfer.xml")
 
 
 def main(target, datauser, omerouser, logdir):
@@ -105,12 +105,13 @@ def main(target, datauser, omerouser, logdir):
     print("stdout prepare:", stdoutval)
     print("stderr prepare:", stderrval)
 
-    edit_xml(target)
+    xml_path = edit_xml(target)
 
     # Move data
 
     datamove = [sys.executable, curr_folder + '/move_data.py',
-                target, fileset_list, logdir, '--timestamp', timestamp]
+                target, fileset_list, xml_path, logdir, '--timestamp',
+                timestamp]
     process = subprocess.Popen(datamove,
                                preexec_fn=demote(data_user_uid,
                                                  data_user_gid,

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -46,11 +46,8 @@ def edit_xml(target, datauser, datagroup):
         imp_json = json.load(fp)
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
-    print(ome)
     ome = add_annotations(ome, imp_json)
-    print(ome)
     ome = move_objects(ome, imp_json)
-    print(ome)
     with open(str(pathlib.Path(target) / "transfer.xml"), "w") as fp:
         print(to_xml(ome), file=fp)
     return str(pathlib.Path(target) / "transfer.xml")

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -86,6 +86,7 @@ def main(target, datauser, omerouser, logdir):
     print("stdout prep:", stdoutval)
     print("stderr prep:", stderrval)
     fileset_list = retrieve_fileset(stdoutval, target)
+    
 
     # Run omero transfer prepare
     env_folder = pathlib.Path(sys.executable).parent
@@ -106,7 +107,13 @@ def main(target, datauser, omerouser, logdir):
     print("stdout prepare:", stdoutval)
     print("stderr prepare:", stderrval)
 
-    xml_path = edit_xml(target)
+    try:
+        f = open(str(pathlib.Path(target) / "import.json"))
+        f.close()
+    except FileNotFoundError:
+        pass
+    else:
+        xml_path = edit_xml(target)
 
     # Move data
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -37,6 +37,7 @@ def retrieve_fileset(stdoutval, target):
     with open(filelist_path, 'w') as f:
         f.write("\n".join(files))
         f.close()
+    os.chmod(filelist_path, 766)
     return filelist_path
 
 

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -42,14 +42,10 @@ def retrieve_fileset(stdoutval, target, datauser, datagroup):
 
 def edit_xml(target, datauser, datagroup):
     ome = from_xml(str(pathlib.Path(target) / "transfer.xml"))
-    print("ome before editing")
-    print(ome)
     with open(str(pathlib.Path(target) / "import.json"), "r") as fp:
         imp_json = json.load(fp)
     ome = add_projects_datasets(ome, imp_json)
-    print(ome)
     ome = add_screens(ome, imp_json)
-    print(ome)
     ome = add_annotations(ome, imp_json)
     print(ome)
     ome = move_objects(ome, imp_json)

--- a/import_workflow.py
+++ b/import_workflow.py
@@ -47,7 +47,7 @@ def edit_xml(target, datauser, datagroup):
     ome = add_projects_datasets(ome, imp_json)
     ome = add_screens(ome, imp_json)
     ome = add_annotations(ome, imp_json)
-    print("after add annotations")
+    print("before move objects")
     print(ome)
     ome = move_objects(ome, imp_json)
     print("after move objects")

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -136,13 +136,14 @@ class DataMover:
                 os.chmod(result, FILE_PERM)
 
         # move transfer.xml
-        result = file_mover(self.xml_path, self.server_path)
-        if result:
-            os.chmod(result, FILE_PERM)
-        else: 
-            result = self.server_path / 'transfer.xml'
-        if result is not None:
-            print(f'XML file moved to {result}')
+        if self.xml_path:
+            result = file_mover(self.xml_path, self.server_path)
+            if result:
+                os.chmod(result, FILE_PERM)
+            else: 
+                result = self.server_path / 'transfer.xml'
+            if result is not None:
+                print(f'XML file moved to {result}')
         
         # Move import.json
         result = file_mover(self.import_json_path, self.server_path)

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -132,8 +132,8 @@ class DataMover:
             #append to server_path
             result = file_mover(src_fp, subfolder_path)
             if result is not None:
-                self.logger.debug(f'Success moving file {src_fp} to '+
-                                  f'the server. It will be imported.')
+                self.logger.debug(f'Success moving file {src_fp} to ' +
+                                  'the server. It will be imported.')
                 os.chmod(result, FILE_PERM)
 
         # move transfer.xml

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -132,7 +132,8 @@ class DataMover:
             #append to server_path
             result = file_mover(src_fp, subfolder_path)
             if result is not None:
-                print(f'Auxiliary file moved to {result}')
+                self.logger.debug(f'Success moving file {src_fp} to '+
+                                  f'the server. It will be imported.')
                 os.chmod(result, FILE_PERM)
 
         # move transfer.xml

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -95,27 +95,27 @@ class DataMover:
                 self.fileset_list = f_list.readlines()
         self.import_path = Path(self.import_json['import_path'])
         self.server_path = Path(self.import_json['server_path'])
-        self.import_targets = self.import_json['import_targets']
+        # self.import_targets = self.import_json['import_targets']
 
     def move_data(self):
         # Prepare destination
         self.server_path.mkdir(mode=DIR_PERM, parents=True, exist_ok=True)
 
         # Move import targets first
-        for target in self.import_targets:
-            src_fp = self.import_path / target['filename']
-            subfolder = target['filename'].rsplit('/',1)
-            if len(subfolder) > 1:
-                subfolder_path = self.server_path / subfolder[0]
-            else:
-                subfolder_path = self.server_path
-            file = str(target['filename'])
-            result = file_mover(src_fp, subfolder_path)
-            if result is not None:
-                print(f'Main file moved to {result}')
-                self.logger.debug(f'Success moving file {file} to '+
-                                  f'the server. It will be imported.')
-                os.chmod(result, FILE_PERM)
+        # for target in self.import_targets:
+        #     src_fp = self.import_path / target['filename']
+        #     subfolder = target['filename'].rsplit('/',1)
+        #     if len(subfolder) > 1:
+        #         subfolder_path = self.server_path / subfolder[0]
+        #     else:
+        #         subfolder_path = self.server_path
+        #     file = str(target['filename'])
+        #     result = file_mover(src_fp, subfolder_path)
+        #     if result is not None:
+        #         print(f'Main file moved to {result}')
+        #         self.logger.debug(f'Success moving file {file} to '+
+        #                           f'the server. It will be imported.')
+        #         os.chmod(result, FILE_PERM)
 
         for target in self.fileset_list:
             src_fp = target.strip()

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -77,10 +77,11 @@ class DataMover:
         into OMERO and hence moved.
     """
 
-    def __init__(self, import_json_path, fileset_list_path):
+    def __init__(self, import_json_path, fileset_list_path, xml_path):
         self.logger = logging.getLogger('datamover')
         self.import_json_path = Path(import_json_path)
         self.fileset_list_path = Path(fileset_list_path)
+        self.xml_path = Path(xml_path)
 
         if not self.import_json_path.exists():
             raise FileNotFoundError('import.json not found')
@@ -134,6 +135,15 @@ class DataMover:
                 print(f'Auxiliary file moved to {result}')
                 os.chmod(result, FILE_PERM)
 
+        # move transfer.xml
+        result = file_mover(self.xml_path, self.server_path)
+        if result:
+            os.chmod(result, FILE_PERM)
+        else: 
+            result = self.server_path / 'transfer.xml'
+        if result is not None:
+            print(f'XML file moved to {result}')
+        
         # Move import.json
         result = file_mover(self.import_json_path, self.server_path)
         if result:

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -37,7 +37,8 @@ def file_mover(file_path, destination_dir, tries=3):
     ersatz_file = destination_dir / 'test.tiff'
     if file_path.exists():
         for i in range(tries):
-            os.makedirs(os.path.dirname(ersatz_file), mode=DIR_PERM, exist_ok=True)
+            os.makedirs(os.path.dirname(ersatz_file), mode=DIR_PERM,
+                        exist_ok=True)
             if destination_dir.exists():
                 shutil.copy(file_path, destination_dir)
                 dest_file = destination_dir / file_path.name
@@ -46,7 +47,8 @@ def file_mover(file_path, destination_dir, tries=3):
                     return str(dest_file)
                 else:
                     fp = str(file_path)
-                    err = f"checksum failed after copy attempt {i + 1} for {fp}"
+                    err = f"checksum failed after copy attempt {i + 1} \
+                          for {fp}"
                     logger.error(err)
                     os.remove(dest_file)
     logger.error(f"Unable to copy {str(file_path)}")
@@ -104,7 +106,7 @@ class DataMover:
         # Move import targets first
         # for target in self.import_targets:
         #     src_fp = self.import_path / target['filename']
-        #     subfolder = target['filename'].rsplit('/',1)
+        #     subfolder = target['filename'].rsplit('/', 1)
         #     if len(subfolder) > 1:
         #         subfolder_path = self.server_path / subfolder[0]
         #     else:
@@ -113,8 +115,8 @@ class DataMover:
         #     result = file_mover(src_fp, subfolder_path)
         #     if result is not None:
         #         print(f'Main file moved to {result}')
-        #         self.logger.debug(f'Success moving file {file} to '+
-        #                           f'the server. It will be imported.')
+        #         self.logger.debug(f'Success moving file {file} to ' +
+        #                           'the server. It will be imported.')
         #         os.chmod(result, FILE_PERM)
 
         for target in self.fileset_list:
@@ -123,13 +125,13 @@ class DataMover:
             src_fp = Path(src_fp)
             if src_fp.suffix == '.log' or src_fp.suffix == '.xlsx':
                 continue
-            subfolder = subfolder_file.rsplit('/',1)
+            subfolder = subfolder_file.rsplit('/', 1)
             if len(subfolder) > 1:
                 subfolder_path = self.server_path / subfolder[0].lstrip('/')
             else:
                 subfolder_path = self.server_path
-            #need to get the file subfolder structure here and
-            #append to server_path
+            # need to get the file subfolder structure here and
+            # append to server_path
             result = file_mover(src_fp, subfolder_path)
             if result is not None:
                 self.logger.debug(f'Success moving file {src_fp} to ' +
@@ -141,16 +143,16 @@ class DataMover:
             result = file_mover(self.xml_path, self.server_path)
             if result:
                 os.chmod(result, FILE_PERM)
-            else: 
+            else:
                 result = self.server_path / 'transfer.xml'
             if result is not None:
                 print(f'XML file moved to {result}')
-        
+
         # Move import.json
         result = file_mover(self.import_json_path, self.server_path)
         if result:
             os.chmod(result, FILE_PERM)
-        else: 
+        else:
             result = self.server_path / 'import.json'
         return f'Ready for import at:{result}'
 

--- a/jax_omeroutils/datamover.py
+++ b/jax_omeroutils/datamover.py
@@ -103,6 +103,7 @@ class DataMover:
         # Prepare destination
         self.server_path.mkdir(mode=DIR_PERM, parents=True, exist_ok=True)
 
+        # LEGACY CODE 
         # Move import targets first
         # for target in self.import_targets:
         #     src_fp = self.import_path / target['filename']

--- a/jax_omeroutils/importer.py
+++ b/jax_omeroutils/importer.py
@@ -259,7 +259,7 @@ class Importer:
                 )
             self.image_ids = [r[0].val for r in results]
             return self.image_ids
-    
+
     def get_plate_ids(self):
         """Get the Ids of imported plates.
 

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -61,11 +61,11 @@ def find_md_file(import_directory):
         if f.suffix.endswith('xlsx'):
             md_files.append(f)
     if len(md_files) == 0:
-        logger.error('No valid metadata file found - have you added an '+
+        logger.error('No valid metadata file found - have you added an ' +
                      'Excel spreadsheet to your files?')
         md_filepath = None
     elif len(md_files) > 1:
-        logger.error('>1 metadata files found, can not process. Is your '+
+        logger.error('>1 metadata files found, can not process. Is your ' +
                      'spreadsheet open? Please close it!')
         md_filepath = None
     else:
@@ -102,8 +102,8 @@ def load_md_from_file(md_filepath, sheet_name=0):
         logger.error(f'Cannot find file {md_filepath} - have you moved it?')
         raise FileNotFoundError(f'No such file: {md_filepath}')
     if md_filepath.suffix != '.xlsx':
-        logger.error('Only spreadsheets with xlsx extensions are accepted. '+
-                      'Please use our template for submission!')
+        logger.error('Only spreadsheets with xlsx extensions are accepted. ' +
+                     'Please use our template for submission!')
         raise ValueError('File suffix must be xlsx')
 
     try:
@@ -115,8 +115,8 @@ def load_md_from_file(md_filepath, sheet_name=0):
                                   dtype=str,
                                   engine="openpyxl")
     except ValueError:
-        logger.error('Your spreadsheet does not have a Submission Form sheet - '+
-                     'please use our template for submission!')
+        logger.error('Your spreadsheet does not have a Submission Form sheet' +
+                     ' - please use our template for submission!')
         raise ValueError(f"Worksheet {sheet_name} does not exist.")
     md = pd.read_excel(md_filepath,
                        sheet_name=sheet_name,
@@ -145,10 +145,10 @@ def load_md_from_file(md_filepath, sheet_name=0):
         md_json['omero_group'] = md_header.loc['OMERO group:', 1].strip()
         md_json['file_metadata'] = md.to_dict(orient='records')
     except KeyError:
-        logger.error("Your spreadsheet does not have 'OMERO user:' or "+
-                     "'OMERO group:' fields, or you have added your username/"+
-                     "group on the same cell as those fields! Please add them "+
-                     "on column B.")
+        logger.error("Your spreadsheet does not have 'OMERO user:' or " +
+                     "'OMERO group:' fields, or you have added your" +
+                     " username/group on the same cell as those fields! " +
+                     "Please add them on column B.")
         raise KeyError("User and group fields are non-existent or malformed.")
     return (md_json)
 
@@ -265,10 +265,10 @@ class ImportBatch:
                 userlist.extend(group_summary[1])
                 userlist = [u.getName() for u in userlist]
                 if user not in userlist:
-                    self.logger.error(f'User {user} is not in group {group} '+
-                                      f'and/or user {user} does not exist. '+
-                                      'Please double-check the spelling and '+
-                                      'note that usernames and group '+
+                    self.logger.error(f'User {user} is not in group {group} ' +
+                                      f'and/or user {user} does not exist. ' +
+                                      'Please double-check the spelling and ' +
+                                      'note that usernames and group ' +
                                       'names are case sensitive!')
                     raise ValueError('User non-existent or not in group.')
                 else:
@@ -277,9 +277,9 @@ class ImportBatch:
                     user_obj = self.conn.getObject('Experimenter', userid)
                     self.user_email = user_obj._obj.email._val
                     return True
-        self.logger.error(f'Group {group} was not found. Please double-check '+
-                          'the spelling and note that usernames and group '+
-                          'names are case sensitive!')
+        self.logger.error(f'Group {group} was not found. Please ' +
+                          'double-check the spelling and note that ' +
+                          'usernames and group names are case sensitive!')
         raise ValueError('group not found.')
 
     def set_server_path(self):
@@ -314,52 +314,53 @@ class ImportBatch:
         self.valid_md = True
         for filemd in self.md['file_metadata']:
             if 'filename' not in filemd.keys():
-                self.logger.error('Column \'filename\' is missing in your '+
+                self.logger.error('Column \'filename\' is missing in your ' +
                                   'spreadsheet!')
                 self.valid_md = False
                 return False
             elif (str(filemd['filename']) == '' or
                   str(filemd['filename']) == 'nan'):
-                self.logger.error('You have an empty filename in your '+
+                self.logger.error('You have an empty filename in your ' +
                                   'spreadsheet. Please double-check!')
                 self.valid_md = False
                 return False
 
             if 'dataset' not in filemd.keys():
                 if 'screen' not in filemd.keys():
-                    self.logger.error('You need either a \'dataset\' or a \'screen\''+
-                                  ' column in your spreadsheet!')
+                    self.logger.error('You need either a \'dataset\' ' +
+                                      'or a \'screen\' column in your' +
+                                      'spreadsheet!')
                     self.valid_md = False
                     return False
                 elif (str(filemd['screen']) == '' or
                       str(filemd['screen']) == 'nan'):
-                    self.logger.error('You have an empty screen name in '+
-                                  'your spreadsheet. Please double-check!')
+                    self.logger.error('You have an empty screen name in ' +
+                                      'your spreadsheet. Please double-check!')
                     self.valid_md = False
                     return False
 
             elif (str(filemd['dataset']) == '' or
                   str(filemd['dataset']) == 'nan'):
-                self.logger.error('You have an empty dataset name in '+
+                self.logger.error('You have an empty dataset name in ' +
                                   'your spreadsheet. Please double-check!')
                 self.valid_md = False
                 return False
 
             if 'project' not in filemd.keys():
                 if 'screen' not in filemd.keys():
-                    self.logger.error('You need either a \'project\' or a \'screen\''+
-                                  ' column in your spreadsheet!')
+                    self.logger.error('You need either a \'project\' or a ' +
+                                      '\'screen\' column in your spreadsheet!')
                     self.valid_md = False
                     return False
                 elif (str(filemd['screen']) == '' or
                       str(filemd['screen']) == 'nan'):
-                    self.logger.error('You have an empty screen name in '+
-                                  'your spreadsheet. Please double-check!')
+                    self.logger.error('You have an empty screen name in ' +
+                                      'your spreadsheet. Please double-check!')
                     self.valid_md = False
                     return False
             elif (str(filemd['project']) == '' or
                   str(filemd['project']) == 'nan'):
-                self.logger.error('You have an empty project name in '+
+                self.logger.error('You have an empty project name in ' +
                                   'your spreadsheet. Please double-check!')
                 self.valid_md = False
                 return False
@@ -367,7 +368,7 @@ class ImportBatch:
         # Check for duplicate filenames in metadata
         file_list_md = [f['filename'] for f in self.md['file_metadata']]
         if len(set(file_list_md)) < len(file_list_md):
-            self.logger.error('Spreadsheet contains duplicate filenames. '+
+            self.logger.error('Spreadsheet contains duplicate filenames. ' +
                               'Please double-check!')
             self.valid_md = False
             return False
@@ -382,16 +383,16 @@ class ImportBatch:
             if imp_target.exists:
                 imp_target.validate_target()
             else:
-                err = f'Target does not exist: {imp_target.path_to_target}. '+\
-                      'This file is in your spreadsheet but not in your '+\
-                      'folder, and will not be imported.'
+                err = f'Target does not exist: {imp_target.path_to_target}. '\
+                      + 'This file is in your spreadsheet but not in your '\
+                      + 'folder, and will not be imported.'
                 self.logger.error(err)
             if imp_target.valid_target is True:
                 self.import_target_list.append(imp_target)
             elif imp_target.valid_target is False:
-                err = ('Target can not be imported'+
-                       f' by OMERO: {imp_target.path_to_target}. File might be '+
-                       'corrupted or invalid. Skipping.')
+                err = ('Target can not be imported' +
+                       f' by OMERO: {imp_target.path_to_target}. File ' +
+                       'might be corrupted or invalid. Skipping.')
                 self.logger.error(err)
 
     def write_json(self):
@@ -400,16 +401,16 @@ class ImportBatch:
         mandatory = [self.user, self.group, self.user_email,
                      self.md, self.server_path]
         if None in mandatory:
-            self.logger.error("Cannot write import.json, missing or wrong "+
-                              "information in one of the following items: "+
+            self.logger.error("Cannot write import.json, missing or wrong " +
+                              "information in one of the following items: " +
                               "username, group, metadata spreadsheet")
             return False
         elif self.valid_md is False:
-            self.logger.error("Cannot write import.json, metadata "+
+            self.logger.error("Cannot write import.json, metadata " +
                               "spreadsheet contains invalid values.")
             return False
         elif len(self.import_target_list) == 0:
-            self.logger.error("Cannot write import.json, no valid "+
+            self.logger.error("Cannot write import.json, no valid " +
                               "import targets. Skipping empty import.")
             return False
         else:

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -479,6 +479,7 @@ class ImportTarget:
 
         cli = CLI()
         cli.register('import', ImportControl, '_')
+        print("path to target:")
         print(self.path_to_target)
         cli.invoke(['import', '-f', str(self.path_to_target)])
 

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -149,8 +149,9 @@ def load_md_from_file(md_filepath, sheet_name=0):
                      "'OMERO group:' fields, or you have added your username/"+
                      "group on the same cell as those fields! Please add them "+
                      "on column B.")
-        raise KeyError(f"User and group fields are non-existent or malformed.")
-    return(md_json)
+        raise KeyError("User and group fields are non-existent or malformed.")
+    return (md_json)
+
 
 # Class definitions #
 #####################
@@ -419,12 +420,18 @@ class ImportBatch:
             import_json['user_supplied_md'] = self.md
             import_json['server_path'] = str(self.server_path)
             import_json['import_path'] = str(self.import_path)
-            import_json['import_targets'] = []
-            for target in self.import_target_list:
-                import_json['import_targets'].append(target.target_md)
+            # import_json['import_targets'] = []
+            # for target in self.import_target_list:
+            #     import_json['import_targets'].append(target.target_md)
             with open(self.import_path / 'import.json', 'w') as fp:
                 json.dump(import_json, fp)
             return True
+
+    def write_filelist(self):
+        with open(self.import_path / 'filelist.txt', 'w') as fp:
+            for target in self.import_target_list:
+                print(target.path_to_target, file=fp)
+        return
 
 
 class ImportTarget:

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -130,9 +130,19 @@ def load_md_from_file(md_filepath, sheet_name=0):
     if 'project' in md.columns:
         md = md.dropna(subset=['filename', 'project', 'dataset'])\
              .dropna(axis='columns', how='all')
+        if md.empty:
+            logger.error('Your spreadsheet rows need to contain ' +
+                         'filename, project and dataset names. Cannot ' +
+                         'proceed with import.')
+            raise ValueError('Spreadsheet needs filename, project and dataset')
     elif 'screen' in md.columns:
         md = md.dropna(subset=['filename', 'screen'])\
              .dropna(axis='columns', how='all')
+        if md.empty:
+            logger.error('Your spreadsheet rows need to contain ' +
+                         'filename and screen names. Cannot ' +
+                         'proceed with import.')
+            raise ValueError('Spreadsheet needs filename and screen')
 
     # protect against extra spaces on 'omero user' and 'omero group'
     md_header.index = md_header.index.str.strip()

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -479,6 +479,7 @@ class ImportTarget:
 
         cli = CLI()
         cli.register('import', ImportControl, '_')
+        print(self.path_to_target)
         cli.invoke(['import', '-f', str(self.path_to_target)])
 
         if cli.rv == 0:

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -114,10 +114,10 @@ def load_md_from_file(md_filepath, sheet_name=0):
                                   header=None,
                                   dtype=str,
                                   engine="openpyxl")
-    except KeyError:
+    except ValueError:
         logger.error('Your spreadsheet does not have a Submission Form sheet - '+
                      'please use our template for submission!')
-        raise KeyError(f"Worksheet {sheet_name} does not exist.")
+        raise ValueError(f"Worksheet {sheet_name} does not exist.")
     md = pd.read_excel(md_filepath,
                        sheet_name=sheet_name,
                        skiprows=range(4),

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -479,9 +479,6 @@ class ImportTarget:
 
         cli = CLI()
         cli.register('import', ImportControl, '_')
-        print("path to target:")
-        print(self.path_to_target)
-        print(['import', '-f', str(self.path_to_target)])
         cli.invoke(['import', '-f', str(self.path_to_target)])
 
         if cli.rv == 0:

--- a/jax_omeroutils/intake.py
+++ b/jax_omeroutils/intake.py
@@ -481,6 +481,7 @@ class ImportTarget:
         cli.register('import', ImportControl, '_')
         print("path to target:")
         print(self.path_to_target)
+        print(['import', '-f', str(self.path_to_target)])
         cli.invoke(['import', '-f', str(self.path_to_target)])
 
         if cli.rv == 0:

--- a/jax_omeroutils/tests/conftest.py
+++ b/jax_omeroutils/tests/conftest.py
@@ -40,15 +40,17 @@ USERS_TO_CREATE = [
 
 def pytest_addoption(parser):
     parser.addoption("--omero-user", action="store",
-        default=os.environ.get("OMERO_USER", DEFAULT_OMERO_USER))
+                     default=os.environ.get("OMERO_USER", DEFAULT_OMERO_USER))
     parser.addoption("--omero-pass", action="store",
-        default=os.environ.get("OMERO_PASS", DEFAULT_OMERO_PASS))
+                     default=os.environ.get("OMERO_PASS", DEFAULT_OMERO_PASS))
     parser.addoption("--omero-host", action="store",
-        default=os.environ.get("OMERO_HOST", DEFAULT_OMERO_HOST))
+                     default=os.environ.get("OMERO_HOST", DEFAULT_OMERO_HOST))
     parser.addoption("--omero-port", action="store", type=int,
-        default=int(os.environ.get("OMERO_PORT", DEFAULT_OMERO_PORT)))
+                     default=int(os.environ.get("OMERO_PORT",
+                                                DEFAULT_OMERO_PORT)))
     parser.addoption("--omero-secure", action="store",
-        default=bool(os.environ.get("OMERO_SECURE", DEFAULT_OMERO_SECURE)))
+                     default=bool(os.environ.get("OMERO_SECURE",
+                                                 DEFAULT_OMERO_SECURE)))
 
 
 # we can change this later
@@ -59,7 +61,7 @@ def omero_params(request):
     host = request.config.getoption("--omero-host")
     port = request.config.getoption("--omero-port")
     secure = request.config.getoption("--omero-secure")
-    return(user, password, host, port, secure)
+    return (user, password, host, port, secure)
 
 
 @pytest.fixture(scope='session')

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -83,8 +83,6 @@ def add_annotations(ome, imp_json):
         return newome
     elif 'screen' in columns:
         newome = add_annotations_plates(ome, imp_json)
-        print("end of add annotations")
-        print(newome)
         return newome
     return ome
     
@@ -231,4 +229,4 @@ def move_plates(ome, imp_json):
                 for scr in newome.screens:
                     if scr.id in right_scr:
                         scr.plate_ref.append(plref)
-    return
+    return newome

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -59,7 +59,14 @@ def add_screens(ome, imp_json):
     if 'screen' not in columns:
         return ome
     else:
-        print(columns)
+        md = imp_json['user_supplied_md']['file_metadata']
+        scr_count = 1
+        screens = [i['screen'] for i in md]
+        for scr in list(set(screens)):
+            id = f"Screen:{scr_count}"
+            scr_count += 1
+            scr_obj = create_screen(id=id, name=scr)
+            newome.screens.append(scr_obj)
     return newome
 
 
@@ -72,5 +79,11 @@ def add_annotations(ome, imp_json):
         columns.remove('dataset')
     if 'screen' in columns:
         columns.remove('screen')
+    md = imp_json['user_supplied_md']['file_metadata']
     print(columns)
+    for line in md:
+        filename = line['filename']
+        ann_dict = {i:line[i] for i in columns}
+        ann_dict.pop('filename')
+        print(ann_dict)
     return newome

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -1,4 +1,29 @@
 import copy
+from collections import defaultdict
+from ome_types.model import Project, Screen, Dataset, MapAnnotation
+from ome_types.model import DatasetRef, AnnotationRef
+
+
+def create_proj(**kwargs):
+    proj = Project(**kwargs)
+    return proj
+
+
+def create_screen(**kwargs):
+    scr = Screen(**kwargs)
+    return scr
+
+
+def create_dataset_and_ref(**kwargs):
+    ds = Dataset(**kwargs)
+    ds_ref = DatasetRef(id=ds.id)
+    return ds, ds_ref
+
+
+def create_kv_and_ref(**kwargs):
+    kv = MapAnnotation(**kwargs)
+    kvref = AnnotationRef(id=kv.id)
+    return kv, kvref
 
 
 def add_projects_datasets(ome, imp_json):
@@ -7,7 +32,24 @@ def add_projects_datasets(ome, imp_json):
     if 'project' not in columns:
         return ome
     else:
-        print(columns)
+        md = imp_json['user_supplied_md']['file_metadata']
+        proj_ds = defaultdict(list)
+        for i in md:
+            proj_ds[i['project']].append(i['dataset'])
+        proj_count = 1
+        ds_count = 1
+        for project in proj_ds.keys():
+            id = f"Project:{proj_count}"
+            proj_count += 1
+            name = project
+            proj = create_proj(id=id, name=name)
+            for dataset in proj_ds[project]:
+                id = f"Dataset:{ds_count}"
+                ds_count += 1
+                ds, ds_ref = create_dataset_and_ref(id=id, name=dataset)
+                newome.datasets.append(ds)
+                proj.dataset_ref.append(ds_ref)
+            newome.projects.append(proj)
     return newome
 
 
@@ -23,11 +65,12 @@ def add_screens(ome, imp_json):
 
 def add_annotations(ome, imp_json):
     newome = copy.deepcopy(ome)
-    columns = imp_json['user_supplied_md']['file_metadata'][0].keys()
+    columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'project' in columns:
         columns.remove('project')
     if 'dataset' in columns:
         columns.remove('dataset')
     if 'screen' in columns:
         columns.remove('screen')
+    print(columns)
     return newome

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -1,0 +1,10 @@
+def add_projects_datasets(ome, imp_json):
+    return ome
+
+
+def add_screens(ome, imp_json):
+    return ome
+
+
+def add_annotations(ome, imp_json):
+    return ome

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -170,7 +170,7 @@ def add_annotations_plates(ome, imp_json):
                             newome.structured_annotations.append(ann)
                             pl.annotation_ref.append(annref)
             print(newome, line)
-    return
+    return newome
 
 
 def move_objects(ome, imp_json):

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -35,7 +35,7 @@ def create_kv_and_ref(**kwargs):
 def add_projects_datasets(ome, imp_json):
     newome = copy.deepcopy(ome)
     columns = imp_json['user_supplied_md']['file_metadata'][0].keys()
-    if 'project' not in columns:
+    if ('project' not in columns) or ('dataset' not in columns):
         return ome
     else:
         md = imp_json['user_supplied_md']['file_metadata']

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -119,12 +119,12 @@ def add_annotations_images(ome, imp_json):
                                     mmap.append(M(k=_key, value=str(_value)))
                                 else:
                                     mmap.append(M(k=_key, value=''))
-                            ann, annref = create_kv_and_ref(
+                            kv, annref = create_kv_and_ref(
                                 id=f"Annotation:{ann_count}",
                                 namespace=CURRENT_MD_NS,
                                 value=Map(ms=mmap))
                             ann_count += 1
-                            newome.structured_annotations.append(ann)
+                            newome.structured_annotations.append(kv)
                             i.annotation_ref.append(annref)
     return newome
 
@@ -159,12 +159,12 @@ def add_annotations_plates(ome, imp_json):
                                     mmap.append(M(k=_key, value=str(_value)))
                                 else:
                                     mmap.append(M(k=_key, value=''))
-                            ann, annref = create_kv_and_ref(
+                            kv, annref = create_kv_and_ref(
                                 id=f"Annotation:{ann_count}",
                                 namespace=CURRENT_MD_NS,
                                 value=Map(ms=mmap))
                             ann_count += 1
-                            newome.structured_annotations.append(ann)
+                            newome.structured_annotations.append(kv)
                             pl.annotation_ref.append(annref)
     return newome
 

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -168,6 +168,8 @@ def add_annotations_plates(ome, imp_json):
 
 
 def move_objects(ome, imp_json):
+    print("in move objects")
+    print(ome)
     columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'project' in columns:
         newome = move_images(ome, imp_json)
@@ -208,7 +210,10 @@ def move_images(ome, imp_json):
 
 
 def move_plates(ome, imp_json):
+    print("in move plates")
+    print(ome)
     newome = copy.deepcopy(ome)
+    print(newome)
     md = imp_json['user_supplied_md']['file_metadata']
     for line in md:
         scrname = line['screen']

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -77,6 +77,8 @@ def add_screens(ome, imp_json):
 
 
 def add_annotations(ome, imp_json):
+    print("in add annotations")
+    print(ome)
     columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'project' in columns:
         newome = add_annotations_images(ome, imp_json)
@@ -129,7 +131,10 @@ def add_annotations_images(ome, imp_json):
 
 
 def add_annotations_plates(ome, imp_json):
+    print("in add annotations plates")
+    print(ome)
     newome = copy.deepcopy(ome)
+    print(newome)
     columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'screen' in columns:
         columns.remove('screen')

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -39,9 +39,9 @@ def add_projects_datasets(ome, imp_json):
         return ome
     else:
         md = imp_json['user_supplied_md']['file_metadata']
-        proj_ds = defaultdict(list)
+        proj_ds = defaultdict(set)
         for i in md:
-            proj_ds[i['project']].append(i['dataset'])
+            proj_ds[i['project']].add(i['dataset'])
         proj_count = 1
         ds_count = 1
         for project in proj_ds.keys():
@@ -86,7 +86,6 @@ def add_annotations(ome, imp_json):
         return newome
     return ome
     
-
 
 def add_annotations_images(ome, imp_json):
     newome = copy.deepcopy(ome)

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -77,14 +77,14 @@ def add_screens(ome, imp_json):
 
 
 def add_annotations(ome, imp_json):
-    print("in add annotations")
-    print(ome)
     columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'project' in columns:
         newome = add_annotations_images(ome, imp_json)
         return newome
     elif 'screen' in columns:
         newome = add_annotations_plates(ome, imp_json)
+        print("end of add annotations")
+        print(newome)
         return newome
     return ome
     

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -131,10 +131,7 @@ def add_annotations_images(ome, imp_json):
 
 
 def add_annotations_plates(ome, imp_json):
-    print("in add annotations plates")
-    print(ome)
     newome = copy.deepcopy(ome)
-    print(newome)
     columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'screen' in columns:
         columns.remove('screen')
@@ -169,7 +166,6 @@ def add_annotations_plates(ome, imp_json):
                             ann_count += 1
                             newome.structured_annotations.append(ann)
                             pl.annotation_ref.append(annref)
-            print(newome, line)
     return newome
 
 

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -169,12 +169,11 @@ def add_annotations_plates(ome, imp_json):
                             ann_count += 1
                             newome.structured_annotations.append(ann)
                             pl.annotation_ref.append(annref)
+            print(newome, line)
     return
 
 
 def move_objects(ome, imp_json):
-    print("in move objects")
-    print(ome)
     columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'project' in columns:
         newome = move_images(ome, imp_json)
@@ -215,10 +214,7 @@ def move_images(ome, imp_json):
 
 
 def move_plates(ome, imp_json):
-    print("in move plates")
-    print(ome)
     newome = copy.deepcopy(ome)
-    print(newome)
     md = imp_json['user_supplied_md']['file_metadata']
     for line in md:
         scrname = line['screen']

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -122,7 +122,7 @@ def add_annotations_images(ome, imp_json):
                                     mmap.append(M(k=_key, value=''))
                             ann, annref = create_kv_and_ref(
                                 id=f"Annotation:{ann_count}", ns=CURRENT_MD_NS,
-                                value=Map(m=mmap))
+                                value=Map(ms=mmap))
                             ann_count += 1
                             newome.structured_annotations.append(ann)
                             i.annotation_ref.append(annref)

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -76,6 +76,18 @@ def add_screens(ome, imp_json):
 
 
 def add_annotations(ome, imp_json):
+    columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
+    if 'project' in columns:
+        newome = add_annotations_images(ome, imp_json)
+        return newome
+    elif 'screen' in columns:
+        newome = add_annotations_plates(ome, imp_json)
+        return newome
+    return ome
+    
+
+
+def add_annotations_images(ome, imp_json):
     newome = copy.deepcopy(ome)
     columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
     if 'project' in columns:
@@ -116,6 +128,21 @@ def add_annotations(ome, imp_json):
     return newome
 
 
+def add_annotations_plates(ome, imp_json):
+    return
+
+
+def move_objects(ome, imp_json):
+    columns = list(imp_json['user_supplied_md']['file_metadata'][0].keys())
+    if 'project' in columns:
+        newome = move_images(ome, imp_json)
+        return newome
+    elif 'screen' in columns:
+        newome = move_plates(ome, imp_json)
+        return newome
+    return ome
+
+
 def move_images(ome, imp_json):
     newome = copy.deepcopy(ome)
     md = imp_json['user_supplied_md']['file_metadata']
@@ -145,3 +172,7 @@ def move_images(ome, imp_json):
                     if ds.id in right_ds:
                         ds.image_ref.append(imgref)
     return newome
+
+
+def move_plates(ome, imp_json):
+    return

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -1,10 +1,33 @@
+import copy
+
+
 def add_projects_datasets(ome, imp_json):
-    return ome
+    newome = copy.deepcopy(ome)
+    columns = imp_json['user_supplied_md']['file_metadata'][0].keys()
+    if 'project' not in columns:
+        return ome
+    else:
+        print(columns)
+    return newome
 
 
 def add_screens(ome, imp_json):
-    return ome
+    newome = copy.deepcopy(ome)
+    columns = imp_json['user_supplied_md']['file_metadata'][0].keys()
+    if 'screen' not in columns:
+        return ome
+    else:
+        print(columns)
+    return newome
 
 
 def add_annotations(ome, imp_json):
-    return ome
+    newome = copy.deepcopy(ome)
+    columns = imp_json['user_supplied_md']['file_metadata'][0].keys()
+    if 'project' in columns:
+        columns.remove('project')
+    if 'dataset' in columns:
+        columns.remove('dataset')
+    if 'screen' in columns:
+        columns.remove('screen')
+    return newome

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -85,7 +85,7 @@ def add_annotations(ome, imp_json):
         newome = add_annotations_plates(ome, imp_json)
         return newome
     return ome
-    
+
 
 def add_annotations_images(ome, imp_json):
     newome = copy.deepcopy(ome)

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -120,7 +120,8 @@ def add_annotations_images(ome, imp_json):
                                 else:
                                     mmap.append(M(k=_key, value=''))
                             ann, annref = create_kv_and_ref(
-                                id=f"Annotation:{ann_count}", ns=CURRENT_MD_NS,
+                                id=f"Annotation:{ann_count}",
+                                namespace=CURRENT_MD_NS,
                                 value=Map(ms=mmap))
                             ann_count += 1
                             newome.structured_annotations.append(ann)
@@ -159,8 +160,9 @@ def add_annotations_plates(ome, imp_json):
                                 else:
                                     mmap.append(M(k=_key, value=''))
                             ann, annref = create_kv_and_ref(
-                                id=f"Annotation:{ann_count}", ns=CURRENT_MD_NS,
-                                value=Map(m=mmap))
+                                id=f"Annotation:{ann_count}",
+                                namespace=CURRENT_MD_NS,
+                                value=Map(ms=mmap))
                             ann_count += 1
                             newome.structured_annotations.append(ann)
                             pl.annotation_ref.append(annref)

--- a/jax_omeroutils/xml_editor.py
+++ b/jax_omeroutils/xml_editor.py
@@ -83,7 +83,8 @@ def add_annotations(ome, imp_json):
     print(columns)
     for line in md:
         filename = line['filename']
-        ann_dict = {i:line[i] for i in columns}
+        ann_dict = {i: line[i] for i in columns}
         ann_dict.pop('filename')
+        ann_dict = {k: v for k, v in ann_dict.items() if isinstance(v, str)}
         print(ann_dict)
     return newome

--- a/move_data.py
+++ b/move_data.py
@@ -4,10 +4,12 @@ from jax_omeroutils.datamover import DataMover
 from pathlib import Path
 
 
-def main(import_batch_directory, fileset_list, log_directory, timestamp):
+def main(import_batch_directory, fileset_list,
+         xml_path, log_directory, timestamp):
     # Move files into place
     if Path(import_batch_directory / 'import.json').exists():
-        mover = DataMover(import_batch_directory / 'import.json', fileset_list)
+        mover = DataMover(import_batch_directory / 'import.json', fileset_list,
+                          xml_path)
         mover.set_logging(log_directory, timestamp)
         message = mover.move_data()
         print(message)
@@ -25,6 +27,10 @@ if __name__ == "__main__":
                         type=str,
                         help='Text file with list of files that need'
                              ' to be transfered')
+    parser.add_argument('xml_path',
+                        type=str,
+                        help='path to a valid transfer.xml to be used with '
+                             'omero transfer unpack')
     parser.add_argument('log_directory',
                         type=str,
                         help='Directory for the log files')
@@ -36,4 +42,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(Path(args.import_batch_directory), Path(args.fileset_list),
-         Path(args.log_directory), args.timestamp)
+         Path(args.xml_path), Path(args.log_directory), args.timestamp)

--- a/prepare_batch.py
+++ b/prepare_batch.py
@@ -19,7 +19,8 @@ def main(import_batch_directory, log_directory, timestamp):
     conn = BlitzGateway(OMERO_USER,
                         OMERO_PASS,
                         host=OMERO_HOST,
-                        port=OMERO_PORT)
+                        port=OMERO_PORT,
+                        secure=True)
     conn.connect()
     batch = ImportBatch(conn, import_batch_directory)
     batch.set_logging(log_directory, timestamp)
@@ -33,6 +34,7 @@ def main(import_batch_directory, log_directory, timestamp):
     batch.set_server_path()
     batch.load_targets()
     batch.write_json()
+    batch.write_filelist()
     conn.close()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=1.1.5
 numpy>=1.19.5,<2.0.0
 ezomero>=0.3.1
 openpyxl==3.0.9
-omero-cli-transfer==0.7.1
+omero-cli-transfer==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-zeroc-ice==3.6.5
-omero-py==5.10.0
-pandas==1.1.5
-numpy==1.19.5
+pandas>=1.1.5
+numpy>=1.19.5,<2.0.0
 ezomero>=0.3.1
 openpyxl==3.0.9
+omero-cli-transfer==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=1.1.5
 numpy>=1.19.5,<2.0.0
 ezomero>=0.3.1
 openpyxl==3.0.9
-omero-cli-transfer==0.7.0
+omero-cli-transfer==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=1.1.5
-numpy>=1.19.5,<2.0.0
-ezomero>=0.3.1
+numpy>=1.22.0,<2.0.0
+ezomero>=2.1.0
 openpyxl==3.0.9
 omero-cli-transfer==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=1.1.5
 numpy>=1.19.5,<2.0.0
 ezomero>=0.3.1
 openpyxl==3.0.9
-omero-cli-transfer==0.6.0
+omero-cli-transfer==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=1.1.5
 numpy>=1.22.0,<2.0.0
-ezomero>=2.1.0
+ezomero>=2.1.0,<3.0.0
 openpyxl==3.0.9
-omero-cli-transfer==0.7.3
+omero-cli-transfer>=0.7.3,<1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=1.1.5
 numpy>=1.19.5,<2.0.0
 ezomero>=0.3.1
 openpyxl==3.0.9
-omero-cli-transfer==0.7.2
+omero-cli-transfer==0.7.3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="jax-omeroutils",
-    version="0.0.1",
+    version="0.1.1",
     maintainer="Dave Mellert",
     maintainer_email="Dave.Mellert@jax.org",
     description=("A package for working with OMERO"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     maintainer="Dave Mellert",
     maintainer_email="Dave.Mellert@jax.org",
     description=("A package for working with OMERO"
-                 "by ResearchIT at The Jackson Laboratory."),
+                 "by Research IT at The Jackson Laboratory."),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/TheJacksonLaboratory/jax-omeroutils",
@@ -19,7 +19,8 @@ setuptools.setup(
         'pandas',
         'numpy',
         'openpyxl',
-        'ezomero'
+        'ezomero',
+        'omero-cli-transfer'
     ],
-    python_requires='>=3.6'
+    python_requires='>=3.8'
 )


### PR DESCRIPTION
This update reworks jax-omeroutils significantly to use omero-cli-transfer as the mechanism to import and annotate images. It also includes a fix for #24 .